### PR TITLE
Use pipx to install bs-highlighter.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM debian:stable-slim
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends ca-certificates curl git python3 python3-pip && \
+    apt-get install --yes --no-install-recommends ca-certificates curl git python3 python3-pip pipx && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/whatwg/wattsi:latest /whatwg/wattsi/bin/wattsi /bin/wattsi
 
-RUN pip3 install bs-highlighter
+ENV PIPX_HOME /opt/pipx
+ENV PIPX_BIN_DIR /usr/bin
+RUN pipx install bs-highlighter
 
 COPY . /whatwg/html-build/
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build locally, you'll need the following commands installed on your system:
 
 - `curl`, `grep`, `perl`, `unzip`
 
-Optionally, for faster builds, you can install [Wattsi](https://github.com/whatwg/wattsi) and Python 3.7+ (necessary for applying syntax highlighting to `pre` contents). If you don't bother with that, the build will use [Wattsi Server](https://github.com/whatwg/build.whatwg.org), which requires an internet connection.
+Optionally, for faster builds, you can install [Wattsi](https://github.com/whatwg/wattsi). If you don't bother with that, the build will use [Wattsi Server](https://github.com/whatwg/build.whatwg.org), which requires an internet connection. If you do use a local build of Wattsi, you'll likely also want Python 3.7+ with [pipx](https://pypa.github.io/pipx/), to enable syntax highlighting of `pre` contents.
 
 ### Running the build
 

--- a/build.sh
+++ b/build.sh
@@ -218,13 +218,13 @@ function checkHTMLBuildIsUpToDate {
 function ensureHighlighterInstalled {
   # If we're not using local Wattsi then we won't use the local highlighter.
   if [[ $LOCAL_WATTSI == "true" && $DO_HIGHLIGHT == "true" ]]; then
-    if hash pip3 2>/dev/null; then
+    if hash pipx 2>/dev/null; then
       if ! hash bs-highlighter-server 2>/dev/null; then
-        pip3 install bs-highlighter
+        pipx install bs-highlighter
       fi
     else
       echo
-      echo "Warning: could not find pip3 in your PATH. Disabling syntax highlighting."
+      echo "Warning: could not find pipx in your PATH. Disabling syntax highlighting."
       echo
       DO_HIGHLIGHT="false"
     fi
@@ -650,7 +650,7 @@ function runWattsi {
     wattsi "${WATTSI_ARGS[@]}" || WATTSI_RESULT=$?
   else
     $QUIET || echo
-    $QUIET || echo "Local wattsi or pip3 are not present; trying the build server..."
+    $QUIET || echo "Local wattsi not present; trying the build server..."
 
     CURL_URL="https://build.whatwg.org/wattsi"
     if [[ "$QUIET" == "true" && "$SINGLE_PAGE_ONLY" == "true" ]]; then

--- a/ci-build/Dockerfile
+++ b/ci-build/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     ca-certificates curl rsync git                \
     default-jre                                   \
     python3 python3-pip pipx                      \
+    libbrotli1 libexpat1 libfontconfig1 libfreetype6 libpng16-16 \
     fonts-dejavu fonts-droid-fallback fonts-liberation fonts-symbola fonts-unfonts-core
 
 # Dependency lines above are:
@@ -28,11 +29,14 @@ ADD https://github.com/validator/validator/releases/download/latest/vnu.jar /wha
 # Trying to copy Prince from its DockerHub container like the others does not work; it has too many
 # shared library dependencies. Probably this is a job for Docker Compose... we should learn how that
 # works one day.
-ADD https://www.princexml.com/download/prince_14.2-1_debian10_amd64.deb /whatwg/prince.deb
+# Prince also hasn't been updated for Debian 12 and is no longer installable from its deb file.
+ADD https://www.princexml.com/download/prince-14.2-linux-generic-x86_64.tar.gz /whatwg/prince.tar.gz
 RUN cd /whatwg && \
-    apt-get install --yes ./prince.deb && \
+    tar xvzf prince.tar.gz && \
+    ( cd prince-* && echo /usr | ./install.sh ) && \
     echo '@font-face { font-family: serif; src: local("Symbola") }' >> /usr/lib/prince/style/fonts.css && \
-    rm -rf /whatwg/prince.deb
+    rm -rf prince* && \
+    prince --version
 
 ADD . /whatwg/html-build
 

--- a/ci-build/Dockerfile
+++ b/ci-build/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
     ca-certificates curl rsync git                \
     default-jre                                   \
-    python3 python3-pip                           \
+    python3 python3-pip pipx                      \
     fonts-dejavu fonts-droid-fallback fonts-liberation fonts-symbola fonts-unfonts-core
 
 # Dependency lines above are:
@@ -16,7 +16,10 @@ RUN apt-get update && \
 # - fonts, for when Prince renders to PDF
 
 COPY --from=ghcr.io/whatwg/wattsi:latest /whatwg/wattsi/bin/wattsi /bin/wattsi
-RUN pip3 install bs-highlighter
+
+ENV PIPX_HOME /opt/pipx
+ENV PIPX_BIN_DIR /usr/bin
+RUN pipx install bs-highlighter
 
 # The DockerHub container for the validator only contains the server version, so we get the .jar
 # from GitHub:

--- a/ci-build/Dockerfile
+++ b/ci-build/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
 # - General
 # - validator
 # - Highlighter
+# - Prince
 # - fonts, for when Prince renders to PDF
 
 COPY --from=ghcr.io/whatwg/wattsi:latest /whatwg/wattsi/bin/wattsi /bin/wattsi


### PR DESCRIPTION
Debian now complains about externally managed Python packages.

This installs it into its own little virtual env.